### PR TITLE
Add Claude Code plugin marketplace manifest (closes #1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "effective-html",
+  "owner": {
+    "name": "plannotator"
+  },
+  "description": "Agent skills for elegant, self-contained HTML plans, diagrams, and artifacts.",
+  "plugins": [
+    {
+      "name": "plannotator-effective-html",
+      "source": {
+        "source": "github",
+        "repo": "plannotator/effective-html"
+      },
+      "description": "HTML skills for pragmatic visual artifacts — html, html-diagram, and html-plan.",
+      "homepage": "https://github.com/plannotator/effective-html",
+      "repository": "https://github.com/plannotator/effective-html",
+      "license": "MIT",
+      "keywords": ["html", "diagram", "plan", "svg", "artifacts", "skills"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ npx skills add plannotator/effective-html --skill html-diagram
 npx skills add plannotator/effective-html --skill html-plan
 ```
 
+### As a Claude Code plugin
+
+This repo is also a [plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces). Add it and install:
+
+```
+/plugin marketplace add plannotator/effective-html
+/plugin install plannotator-effective-html@effective-html
+```
+
 ## Skills
 
 - `html` - Create an HTML file for whatever the user is describing, matching the effective HTML references.


### PR DESCRIPTION
Addresses #1 (Claude Code portion).

The repo already ships as a single plugin (root `.claude-plugin/plugin.json`). This adds the marketplace catalog so it installs natively in Claude Code — no change to the existing `npx skills add` flow.

### What's added
- **`.claude-plugin/marketplace.json`** — lists the plugin via a `github` source pointing at this repo (resolves regardless of how the marketplace is added). `version` is omitted so installs track the latest commit.
- **README** — an "As a Claude Code plugin" install section.

### Install
```
/plugin marketplace add plannotator/effective-html
/plugin install plannotator-effective-html@effective-html
```

### Verification
Validated with the real loader — `claude plugin marketplace add` accepted it and listed it cleanly:
```
❯ effective-html
  Source: Directory (...)
```

A companion PR adds the Codex equivalent (built to spec, flagged as untested) so the two can be reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)