### PR TITLE
Simplify repository and site introductions

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -99,8 +99,8 @@ and custom interfaces that it teaches people to create.
 - `README.md` describes the five Effective HTML skills and their intended uses.
 - `skills/` contains the current wireframe, prototype, plan, diagram, and broad
   HTML guidance.
-- `examples/release-readiness/` carries one brief from structural wireframe to
-  interactive prototype with desktop and mobile screenshots.
+- `examples/release-readiness/` contains standalone wireframe and prototype
+  examples with desktop and mobile screenshots.
 - `assets/effective-html-banner.png` is the current repository banner.
 - `art/brand-concepts/working-atlas-v1-refined.png` is the approved site concept
   plate.

--- a/README.md
+++ b/README.md
@@ -29,17 +29,6 @@ Render and annotate local HTML with <a href="https://github.com/backnotprop/plan
 | [`html-plan`](skills/html-plan/SKILL.md) | Plans, roadmaps, rollouts, and implementation sequences that preserve source commitments |
 | [`html-diagram`](skills/html-diagram/SKILL.md) | Architecture, sequence, process, state, hierarchy, timeline, and system diagrams |
 
-## One brief, two stages
-
-The [release-readiness example](examples/release-readiness/README.md) carries the same product brief from structural exploration to working interaction. Both artifacts are standalone HTML files that open without build tooling.
-
-| Wireframe | Prototype |
-| --- | --- |
-| [![Low-fidelity release wireframe](examples/release-readiness/screenshots/wireframe-desktop.png)](examples/release-readiness/wireframe.html) | [![Interactive release prototype](examples/release-readiness/screenshots/prototype-desktop.png)](examples/release-readiness/prototype.html) |
-| Decide what belongs on the screen and compare structural directions. | Test the blocked-to-ready flow, feedback, recovery, and product boundary. |
-
-Read the canonical Plannotator guide, [HTML wireframes and prototypes for coding agents](https://docs.plannotator.ai/learn/code-context/html-wireframes-and-prototypes-for-coding-agents), for the review questions that belong at each stage.
-
 ## Install
 
 Install the collection:

--- a/app/examples/page.tsx
+++ b/app/examples/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Examples",
   description:
-    "Inspect Effective HTML wireframes and prototypes built from the same product brief.",
+    "Open the release-readiness wireframe and prototype as standalone HTML files.",
 };
 
 export default function ExamplesPage() {
@@ -20,11 +20,11 @@ export default function ExamplesPage() {
       <main id="main-content" tabIndex={-1}>
       <section className="examples-hero">
         <div className="examples-hero-copy">
-          <h1>Examples you can inspect, not just admire.</h1>
+          <h1>Release-readiness examples</h1>
           <p>
-            The same release-readiness brief becomes two different artifacts.
-            The wireframe supports structural judgment. The prototype supports
-            behavioral judgment.
+            Open the wireframe to inspect hierarchy, content, and responsive
+            structure. Open the prototype to test the release flow and its
+            states.
           </p>
         </div>
       </section>

--- a/app/global.css
+++ b/app/global.css
@@ -1162,8 +1162,7 @@ strong,
   z-index: 3;
 }
 
-.section-heading h2,
-.example-heading h2 {
+.section-heading h2 {
   max-width: 15ch;
   margin: 0;
   font-size: clamp(3.4rem, 6.3vw, 6rem);
@@ -1173,8 +1172,7 @@ strong,
   text-wrap: balance;
 }
 
-.section-heading p,
-.example-heading p {
+.section-heading p {
   max-width: 36rem;
   margin: 0 0 0.45rem;
   color: #554f47;
@@ -1507,61 +1505,6 @@ strong,
   line-height: 1.55;
 }
 
-.example-story {
-  padding: clamp(6rem, 10vw, 10rem) max(2rem, calc((100vw - var(--content-max)) / 2));
-}
-
-.example-heading {
-  display: grid;
-  position: relative;
-  z-index: 3;
-  grid-template-columns: minmax(0, 1.1fr) minmax(20rem, 0.9fr);
-  gap: 4rem;
-  align-items: end;
-}
-
-.example-visuals {
-  display: grid;
-  position: relative;
-  z-index: 3;
-  grid-template-columns: 0.85fr 1.15fr;
-  gap: 2.5rem;
-  align-items: end;
-  margin: 5rem 0 3rem;
-}
-
-.example-shot {
-  display: block;
-  padding: 0.8rem 0.8rem 1.15rem;
-  border: 1px solid var(--ink);
-  border-radius: 0.45rem;
-  background: var(--paper-bright);
-  box-shadow: 0 18px 34px rgba(20, 20, 19, 0.2);
-}
-
-.example-shot img {
-  display: block;
-  width: 100%;
-  height: auto;
-  border: 1px solid rgba(20, 20, 19, 0.35);
-}
-
-.example-shot span {
-  display: block;
-  margin: 0.85rem 0.15rem 0;
-  font-family: "Inter Tight Variable", sans-serif;
-  font-size: 0.85rem;
-  font-weight: 680;
-}
-
-.example-shot-wireframe {
-  transform: rotate(-2deg);
-}
-
-.example-shot-prototype {
-  transform: rotate(1.25deg);
-}
-
 .catalog-footer {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
@@ -1882,8 +1825,7 @@ strong,
     right: 6%;
   }
 
-  .section-heading,
-  .example-heading {
+  .section-heading {
     grid-template-columns: 1fr;
     gap: 1.75rem;
   }
@@ -2008,14 +1950,12 @@ strong,
   }
 
   .artifact-catalog,
-  .why-html,
-  .example-story {
+  .why-html {
     padding-right: 1rem;
     padding-left: 1rem;
   }
 
   .section-heading h2,
-  .example-heading h2,
   .why-statement h2 {
     font-size: 3.2rem;
   }
@@ -2055,17 +1995,6 @@ strong,
 
   .why-uses > div {
     padding-left: 3.5rem;
-  }
-
-  .example-visuals {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-    margin-top: 3.5rem;
-  }
-
-  .example-shot-wireframe,
-  .example-shot-prototype {
-    transform: none;
   }
 
   .catalog-footer {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,6 @@ import {
   MousePointerClick,
   Network,
 } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 const artifactLinks = [
@@ -175,45 +174,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="catalog-paper example-story">
-        <div className="example-heading">
-          <h2>One brief. Two different decisions.</h2>
-          <p>
-            The release-readiness example moves from structural exploration to
-            working interaction without confusing the purpose of either stage.
-          </p>
-        </div>
-        <div className="example-visuals">
-          <Link
-            className="example-shot example-shot-wireframe"
-            href="/examples#wireframe"
-          >
-            <Image
-              src="/examples/release-readiness/wireframe-desktop.png"
-              alt="Low-fidelity release readiness wireframe"
-              width={1440}
-              height={1000}
-            />
-            <span>Wireframe — decide what belongs</span>
-          </Link>
-          <Link
-            className="example-shot example-shot-prototype"
-            href="/examples#prototype"
-          >
-            <Image
-              src="/examples/release-readiness/prototype-desktop.png"
-              alt="Interactive release readiness prototype"
-              width={1440}
-              height={1428}
-            />
-            <span>Prototype — test how it behaves</span>
-          </Link>
-        </div>
-        <Link className="button button-ink" href="/examples">
-          Open the examples
-          <ArrowUpRight aria-hidden="true" />
-        </Link>
-      </section>
       </main>
 
       <footer className="catalog-footer">

--- a/content/docs/choosing-fidelity.mdx
+++ b/content/docs/choosing-fidelity.mdx
@@ -13,12 +13,12 @@ Choose the lowest fidelity that makes the next human decision visible.
 
 ## Read the decision, not the finish
 
-The same brief can produce five useful artifacts because each form supplies
-different evidence. A wireframe should not be criticized for lacking polish.
-A mockup should not imply that every control works. A prototype should not grow
-into a product simply because the happy path is convincing.
+Choose the artifact that exposes the evidence the review needs. A wireframe
+should not be criticized for lacking polish. A mockup should not imply that
+every control works. A prototype should not grow into a product simply because
+the happy path is convincing.
 
-Move forward only when the decision changes.
+Increase fidelity only when the review depends on new evidence.
 
 ## Wireframe
 
@@ -51,7 +51,7 @@ preserved. Markdown often remains the better medium. Use HTML only when spatial,
 comparative, or interactive presentation makes the plan materially easier to
 understand.
 
-## A practical test
+## Before increasing fidelity
 
 Before raising fidelity, ask:
 

--- a/content/docs/why-html.mdx
+++ b/content/docs/why-html.mdx
@@ -47,8 +47,8 @@ of understanding.
 
 <GuideHandoff
   artifactHref="/examples"
-  artifactLabel="Compare the same brief"
-  artifactDescription="Inspect a wireframe and prototype built from one product decision."
+  artifactLabel="Open the examples"
+  artifactDescription="Inspect the release-readiness wireframe and prototype."
   sourceHref="https://github.com/plannotator/effective-html"
   skillHref="https://github.com/plannotator/effective-html/blob/main/skills/html/SKILL.md"
   skillLabel="Use the HTML router"


### PR DESCRIPTION
Removes the staged brief showcase and the README image table, and rewrites the examples and guide handoffs as direct instructions. The landing page now moves from the introduction to artifact selection to the case for HTML without repeating the same wireframe/prototype story.\n\nValidation: pnpm build; rendered checks of the home, examples, choosing-fidelity, and why-html pages.