### PR TITLE
Clarify catalog sources and add footer references

### DIFF
--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -1,5 +1,6 @@
 import { CatalogExplorer } from "@/components/catalog-explorer";
 import styles from "@/components/catalog-explorer.module.css";
+import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import {
   catalogArtifacts,
@@ -9,7 +10,6 @@ import {
 import { ArrowRight, ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
-import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Catalog",
@@ -175,19 +175,7 @@ export default function CatalogPage() {
       </section>
       </main>
 
-      <footer className="catalog-footer">
-        <div>
-          <strong>Effective HTML</strong>
-          <span>by Plannotator</span>
-        </div>
-        <p>Useful artifacts for developers working with agents.</p>
-        <nav aria-label="Footer navigation">
-          <Link href="/catalog">Catalog</Link>
-          <Link href="/docs">Guide</Link>
-          <Link href="/examples">Examples</Link>
-          <a href="https://github.com/plannotator/effective-html">GitHub</a>
-        </nav>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/app/examples/page.tsx
+++ b/app/examples/page.tsx
@@ -1,3 +1,4 @@
+import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
@@ -83,6 +84,7 @@ export default function ExamplesPage() {
         </article>
       </section>
       </main>
+      <SiteFooter />
     </div>
   );
 }

--- a/app/global.css
+++ b/app/global.css
@@ -1547,6 +1547,22 @@ strong,
   min-height: 2.75rem;
 }
 
+.catalog-footer .footer-references {
+  grid-column: 1 / -1;
+  flex-wrap: wrap;
+  align-items: center;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(243, 230, 210, 0.16);
+}
+
+.catalog-footer .footer-references > span {
+  color: var(--paper-bright);
+  font-size: 0.65rem;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .catalog-footer a:hover {
   color: var(--paper-bright);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
 import { SpecimenStack } from "@/components/specimen-stack";
 import {
   ArrowRight,
@@ -176,19 +177,7 @@ export default function HomePage() {
 
       </main>
 
-      <footer className="catalog-footer">
-        <div>
-          <strong>Effective HTML</strong>
-          <span>by Plannotator</span>
-        </div>
-        <p>Useful artifacts for developers working with agents.</p>
-        <nav aria-label="Footer navigation">
-          <Link href="/catalog">Catalog</Link>
-          <Link href="/docs">Guide</Link>
-          <Link href="/examples">Examples</Link>
-          <a href="https://github.com/plannotator/effective-html">GitHub</a>
-        </nav>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/components/catalog-explorer.module.css
+++ b/components/catalog-explorer.module.css
@@ -607,6 +607,8 @@
 
 .specimenActions {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.65rem;
 }
 

--- a/components/catalog-explorer.tsx
+++ b/components/catalog-explorer.tsx
@@ -87,6 +87,9 @@ function ArtifactSpecimen({
 }) {
   const animated = previewMode === "animated";
   const activeSvg = animated ? artifact.animatedSvg : artifact.staticSvg;
+  const activeSourceUrl = animated
+    ? artifact.animatedSourceUrl
+    : artifact.staticSourceUrl;
 
   return (
     <article className={styles.specimen}>
@@ -115,11 +118,11 @@ function ArtifactSpecimen({
       <div className={styles.specimenControls}>
         <div className={styles.specimenActions}>
           <a href={artifact.htmlUrl} target="_blank" rel="noreferrer">
-            HTML
+            Original HTML
             <ExternalLink aria-hidden="true" />
           </a>
-          <a href={activeSvg} target="_blank" rel="noreferrer">
-            SVG
+          <a href={activeSourceUrl} target="_blank" rel="noreferrer">
+            Effective SVG
             <ExternalLink aria-hidden="true" />
           </a>
           {artifact.resourceUrl && artifact.resourceLabel && (

--- a/components/catalog-folio.module.css
+++ b/components/catalog-folio.module.css
@@ -381,6 +381,7 @@
 
 .specimenLinks {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.8rem;
   margin-top: auto;
   padding-top: 0.7rem;

--- a/components/catalog-folio.tsx
+++ b/components/catalog-folio.tsx
@@ -66,6 +66,9 @@ function FolioSpecimen({
   animated: boolean;
 }) {
   const svg = animated ? artifact.animatedSvg : artifact.staticSvg;
+  const sourceUrl = animated
+    ? artifact.animatedSourceUrl
+    : artifact.staticSourceUrl;
 
   return (
     <article className={styles.specimen}>
@@ -90,11 +93,11 @@ function FolioSpecimen({
         <p>{artifact.description}</p>
         <div className={styles.specimenLinks}>
           <a href={artifact.htmlUrl} target="_blank" rel="noreferrer">
-            HTML
+            Original HTML
             <ArrowUpRight aria-hidden="true" />
           </a>
-          <a href={svg} target="_blank" rel="noreferrer">
-            SVG
+          <a href={sourceUrl} target="_blank" rel="noreferrer">
+            Effective SVG
             <ArrowUpRight aria-hidden="true" />
           </a>
         </div>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  return (
+    <footer className="catalog-footer">
+      <div>
+        <strong>Effective HTML</strong>
+        <span>by Plannotator</span>
+      </div>
+      <p>Useful artifacts for developers working with agents.</p>
+      <nav aria-label="Footer navigation">
+        <Link href="/catalog">Catalog</Link>
+        <Link href="/docs">Guide</Link>
+        <Link href="/examples">Examples</Link>
+        <a href="https://github.com/plannotator/effective-html">GitHub</a>
+      </nav>
+      <nav className="footer-references" aria-label="References">
+        <span>References</span>
+        <a
+          href="https://claude.com/blog/using-claude-code-the-unreasonable-effectiveness-of-html"
+          target="_blank"
+          rel="noreferrer"
+        >
+          The unreasonable effectiveness of HTML
+        </a>
+        <a
+          href="https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Understanding is the new bottleneck
+        </a>
+        <a
+          href="https://thariqs.github.io/html-effectiveness/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Original HTML gallery
+        </a>
+      </nav>
+    </footer>
+  );
+}

--- a/lib/catalog-data.ts
+++ b/lib/catalog-data.ts
@@ -29,6 +29,8 @@ export type CatalogArtifact = {
   resourceLabel?: string;
   staticSvg: string;
   animatedSvg: string;
+  staticSourceUrl: string;
+  animatedSourceUrl: string;
   keywords: string[];
 };
 
@@ -158,6 +160,8 @@ export const catalogCategories: CatalogCategory[] = [
 const svgPaths = (file: string) => ({
   staticSvg: `/catalog/effective-svg/static/${file}.svg`,
   animatedSvg: `/catalog/effective-svg/animated/${file}.svg`,
+  staticSourceUrl: `https://github.com/plannotator/effective-svg/blob/main/svg/${file}.svg`,
+  animatedSourceUrl: `https://github.com/plannotator/effective-svg/blob/main/svg-animated/${file}.svg`,
 });
 
 export const catalogArtifacts: CatalogArtifact[] = [


### PR DESCRIPTION
Keeps the hosted Thariq examples as Original HTML, links each SVG interpretation to its matching source file in plannotator/effective-svg, and retains the rendered SVG preview on the card. Adds a shared public-site footer with the two foundational essays and the original HTML gallery.\n\nValidation: pnpm build; local rendered-content checks on /, /catalog, and /examples.