### PR TITLE
Add the design artifact skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "plannotator"
   },
-  "description": "Focused skills for self-contained HTML artifacts, wireframes, interactive prototypes, plans, and diagrams.",
+  "description": "Creative direction and focused skills for self-contained HTML artifacts, wireframes, interactive prototypes, plans, and diagrams.",
   "plugins": [
     {
       "name": "plannotator-effective-html",
@@ -11,11 +11,11 @@
         "source": "github",
         "repo": "plannotator/effective-html"
       },
-      "description": "Create HTML wireframes, styled mockups, interactive prototypes, plans, diagrams, and general standalone artifacts.",
+      "description": "Give standalone HTML artifacts a subject-specific visual direction, then create wireframes, styled mockups, interactive prototypes, plans, diagrams, and general artifacts.",
       "homepage": "https://github.com/plannotator/effective-html",
       "repository": "https://github.com/plannotator/effective-html",
       "license": "MIT",
-      "keywords": ["html", "wireframe", "prototype", "prototyping", "diagram", "plan", "html-artifacts", "agent-skills", "claude-code", "codex"],
+      "keywords": ["html", "design", "creative-direction", "wireframe", "prototype", "prototyping", "diagram", "plan", "html-artifacts", "agent-skills", "claude-code", "codex"],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "plannotator-effective-html",
   "skills": [
     "./skills/html",
+    "./skills/design-artifact",
     "./skills/html-wireframe",
     "./skills/html-prototype",
     "./skills/html-diagram",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plannotator-effective-html",
-  "version": "0.3.0",
-  "description": "Focused skills for self-contained HTML artifacts, wireframes, interactive prototypes, plans, and diagrams.",
+  "version": "0.4.0",
+  "description": "Creative direction and focused skills for self-contained HTML artifacts, wireframes, interactive prototypes, plans, and diagrams.",
   "author": {
     "name": "plannotator",
     "url": "https://github.com/plannotator"
@@ -9,17 +9,17 @@
   "homepage": "https://github.com/plannotator/effective-html",
   "repository": "https://github.com/plannotator/effective-html",
   "license": "MIT",
-  "keywords": ["html", "wireframe", "prototype", "prototyping", "diagram", "plan", "html-artifacts", "agent-skills", "claude-code", "codex"],
+  "keywords": ["html", "design", "creative-direction", "wireframe", "prototype", "prototyping", "diagram", "plan", "html-artifacts", "agent-skills", "claude-code", "codex"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Effective HTML",
     "shortDescription": "HTML wireframes, prototypes, and artifacts",
-    "longDescription": "Create self-contained HTML artifacts whose direction follows the user's brief, project, and subject, with focused skills for low-fidelity wireframes, styled mockups, interactive prototypes, plans, diagrams, and general HTML work.",
+    "longDescription": "Give self-contained HTML artifacts a visual direction rooted in the user's brief, project, and subject, with focused skills for low-fidelity wireframes, styled mockups, interactive prototypes, plans, diagrams, and general HTML work.",
     "developerName": "plannotator",
     "category": "Productivity",
     "capabilities": ["Write"],
     "defaultPrompt": [
-      "Use $html to choose the right Effective HTML workflow and create a self-contained artifact from this brief."
+      "Use $html to choose the right Effective HTML workflow, and compose $design-artifact when the visual direction remains open."
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Effective HTML
 
-Five focused skills for creating useful, self-contained HTML artifacts, from low-fidelity wireframes to working interactive prototypes.
+Six skills for creating useful, self-contained HTML artifacts, from creative direction and low-fidelity wireframes to working interactive prototypes.
 
 
 https://github.com/user-attachments/assets/24306977-7f30-44c9-9bff-55f901d557b0
@@ -26,6 +26,7 @@ HTML skills for pragmatic visual artifacts.
 | Skill | Use it for |
 | --- | --- |
 | [`html`](skills/html/SKILL.md) | Broad HTML requests, mixed artifacts, reports, explainers, presentations, landing pages, tools, and routing to a specialist |
+| [`design-artifact`](skills/design-artifact/SKILL.md) | Subject-specific creative direction for any HTML artifact without imposing a reusable house style |
 | [`html-wireframe`](skills/html-wireframe/SKILL.md) | Low-fidelity layout directions that test content, hierarchy, navigation, flows, and responsive structure |
 | [`html-prototype`](skills/html-prototype/SKILL.md) | Working prototypes with realistic states, interaction, keyboard support, and responsive behavior |
 | [`html-plan`](skills/html-plan/SKILL.md) | Plans, roadmaps, rollouts, and implementation sequences that preserve source commitments |
@@ -46,6 +47,7 @@ List or install individual skills:
 
 ```bash
 npx skills add plannotator/effective-html --list
+npx skills add plannotator/effective-html --skill design-artifact
 npx skills add plannotator/effective-html --skill html-wireframe
 npx skills add plannotator/effective-html --skill html-prototype
 ```
@@ -56,9 +58,11 @@ Invoke a skill directly:
 Use $html-wireframe to explore three responsive layouts for this checkout brief.
 
 Use $html-prototype to make the checkout flow work, including validation, loading, failure, success, keyboard, and mobile states.
+
+Use $design-artifact with $html-diagram to give this architecture explainer a visual direction rooted in the system it describes.
 ```
 
-Only `$html` is eligible for implicit invocation. Call a specialist directly when you know the artifact type, or use `$html` to route a broad request. Each specialist remains independently usable when invoked directly.
+`$html` can route a broad request, while `$design-artifact` can supply creative direction across artifact types. Call a specialist directly when you know the artifact type. Each specialist remains independently usable when invoked directly.
 
 ### Claude Code plugin
 
@@ -79,13 +83,14 @@ codex plugin add plannotator-effective-html@effective-html
 The skills separate creative freedom from reliability:
 
 - Visual direction comes from the conversation, project, audience, and subject.
+- `design-artifact` provides a reusable design process without prescribing a reusable look.
 - Wireframes stay intentionally unfinished so reviewers focus on structure.
 - Prototypes implement one credible flow and its relevant states.
 - Plans preserve source commitments.
 - Diagrams choose a visual model and rendering method that fit the relationship being explained.
 - Every artifact is responsive, accessible, self-contained, and verified in a browser.
 
-Detailed guidance lives only where it is needed. The broad `html` skill keeps shared references for creative direction, documents, interfaces, diagrams, charts, and data. The specialist skills remain concise and independently usable.
+Detailed guidance lives only where it is needed. The broad `html` skill routes the work, `design-artifact` supplies optional creative direction, and specialist skills own fidelity and behavior. Each skill remains independently usable.
 
 ## Repository shape
 
@@ -95,6 +100,7 @@ skills/
 │   ├── SKILL.md
 │   ├── agents/openai.yaml
 │   └── references/
+├── design-artifact/
 ├── html-wireframe/
 ├── html-prototype/
 ├── html-plan/

--- a/site/PRODUCT.md
+++ b/site/PRODUCT.md
@@ -97,8 +97,8 @@ and custom interfaces that it teaches people to create.
 ## Evidence on Hand
 
 - `../README.md` describes the five Effective HTML skills and their intended uses.
-- `../skills/` contains the current wireframe, prototype, plan, diagram, and broad
-  HTML guidance.
+- `../skills/` contains the current creative-direction, wireframe, prototype,
+  plan, diagram, and broad HTML guidance.
 - `../examples/release-readiness/` contains standalone wireframe and prototype
   examples with desktop and mobile screenshots.
 - `public/brand/effective-html-banner.png` is the deployed site banner.

--- a/site/app/catalog/page.tsx
+++ b/site/app/catalog/page.tsx
@@ -5,6 +5,7 @@ import { SiteHeader } from "@/components/site-header";
 import {
   catalogArtifacts,
   catalogCategories,
+  catalogSkills,
   nativeExamples,
 } from "@/lib/catalog-data";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
@@ -67,8 +68,9 @@ export default function CatalogPage() {
           <div className={styles.heroTitle}>
             <h1>Catalog</h1>
             <p>
-              The work itself: twenty HTML references, forty SVG renderings,
-              five skills, and six native artifacts you can open and inspect.
+              The work itself: twenty HTML references, forty SVG renderings,{" "}
+              {catalogSkills.length} skills, and six native artifacts you can
+              open and inspect.
             </p>
             <a href="#catalog-collection">
               Browse the collection

--- a/site/components/catalog-explorer.tsx
+++ b/site/components/catalog-explorer.tsx
@@ -56,7 +56,7 @@ const collectionOptions: Array<{
     label: "Hi-fi mockups",
     count: highFidelityMockups.length,
   },
-  { id: "skills", label: "Skills", count: 5 },
+  { id: "skills", label: "Skills", count: catalogSkills.length },
 ];
 
 const totalEntryCount = collectionOptions[0].count;

--- a/site/content/docs/designing-artifacts.mdx
+++ b/site/content/docs/designing-artifacts.mdx
@@ -1,0 +1,106 @@
+---
+title: Designing artifacts
+description: Give any HTML artifact a visual direction rooted in its subject rather than a static template.
+---
+
+You can make an effective HTML artifact without installing a skill. When you do
+want reusable creative-direction guidance, use
+[`design-artifact`](https://github.com/plannotator/effective-html/blob/main/skills/design-artifact/SKILL.md)
+alongside the artifact workflow.
+
+The skill does not decide whether the work should be a wireframe, prototype,
+plan, diagram, deck, report, or tool. It decides how the chosen form should feel:
+its visual register, palette, type, composition, theming, and amount of
+expressive treatment.
+
+## Compose skills instead of stacking rules
+
+Let one skill own the artifact's form and let `design-artifact` supply creative
+direction:
+
+- `html` routes a broad request and provides the shared build contract.
+- `html-wireframe` keeps structural exploration visibly low fidelity.
+- `html-prototype` owns mockup fidelity, working states, and interaction.
+- `html-plan` protects source commitments and traceability.
+- `html-diagram` chooses the visual model and rendering method.
+- `design-artifact` shapes the visual identity without overriding those
+  boundaries.
+
+This keeps the instructions thin. The brief, project context, and artifact
+itself still carry the substance.
+
+## Start with authority, not inspiration
+
+Read the user's instructions and accepted decisions first. Then inspect the
+project's design system, tokens, components, screenshots, and nearby artifacts.
+Only after those sources should the agent use its own design judgment.
+
+References are evidence about intent, constraints, and technique. They are not a
+palette, card system, or layout to copy into every new artifact.
+
+## Choose the register
+
+Match the amount of treatment to the work:
+
+- **Workmanlike** for plans, operational reports, briefs, and many tools.
+- **Editorial** for explainers, research stories, launches, and decks that need
+  a stronger point of view.
+- **Expressive** when the visual or interactive premise is part of the subject
+  itself.
+
+Every register deserves careful hierarchy and spacing. Not every artifact needs
+a hero, custom type, animation, or a dense interface.
+
+## Write a short design plan
+
+Before coding, decide:
+
+1. The visual premise and why it belongs to this subject.
+2. The color roles, including neutrals and semantic status colors.
+3. The type roles the content actually needs.
+4. The organizing layout and reading path.
+5. The one place, if any, where interaction or motion carries meaning.
+
+The number of colors, typefaces, columns, and components follows the idea. The
+skill deliberately avoids a fixed theme or component recipe.
+
+## Build, inspect, and revise
+
+Use realistic content from the first draft. Open the result at wide and narrow
+sizes, operate the important controls, and check focus, reduced motion, contrast,
+overflow, and failure states.
+
+Before handoff, ask whether the same visual idea would fit a neighboring topic
+just as well. If it would, the direction is still generic. Revise the
+composition, type, color, imagery, or interaction until it belongs to the brief.
+
+## Inspiration and adaptation
+
+Effective HTML's `design-artifact` skill is a portable, single-file
+interpretation of the artifact-design approach popularized through Claude and
+Claude Code. It was specifically inspired by Anthropic's official
+[`web-artifacts-builder`](https://github.com/anthropics/skills/blob/main/skills/web-artifacts-builder/SKILL.md)
+skill.
+
+Anthropic's skill provides a toolchain for elaborate React artifacts. This
+adaptation focuses on creative direction that can compose with any Effective
+HTML artifact, including quiet plans, wireframes, diagrams, and standalone
+documents. It is maintained by Plannotator and is not an Anthropic skill.
+
+<GuideHandoff
+  artifactHref="/catalog?collection=skills#catalog-collection"
+  artifactLabel="Browse the skill collection"
+  artifactDescription="Compare the generic design layer with the artifact specialists."
+  sourceHref="https://github.com/anthropics/skills/blob/main/skills/web-artifacts-builder/SKILL.md"
+  sourceLabel="Read Anthropic's artifact skill"
+  sourceDescription="See the Claude artifact workflow that inspired this portable adaptation."
+  skillHref="https://github.com/plannotator/effective-html/blob/main/skills/design-artifact/SKILL.md"
+  skillLabel="Use design-artifact"
+  skillDescription="Apply subject-specific creative direction to any HTML artifact."
+/>
+
+<GuideNext
+  href="/docs/choosing-fidelity"
+  title="Choose the lowest useful fidelity"
+  description="Let the decision determine how resolved the artifact should become."
+/>

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -52,8 +52,10 @@ fidelity that answers the current question without creating a new distraction.
 ## What this guide covers
 
 The guide covers wireframes, prototypes, diagrams, browser-native decks, and
-plans. The examples stay inspectable and source-grounded. They demonstrate the
-patterns; they are not prerequisites for using them.
+plans. It also includes a generic [artifact design
+approach](/docs/designing-artifacts) that can sit above any of those forms. The
+examples stay inspectable and source-grounded. They demonstrate the patterns;
+they are not prerequisites for using them.
 
 ## Where this guide comes from
 
@@ -68,5 +70,6 @@ Slides](https://github.com/zarazhangrui/frontend-slides). They share a practical
 idea: agents can produce artifacts that help people inspect, understand, and
 participate in the work.
 
-Continue with [why HTML](/docs/why-html), or go directly to
-[choosing fidelity](/docs/choosing-fidelity).
+Continue with [why HTML](/docs/why-html), learn the generic approach to
+[designing artifacts](/docs/designing-artifacts), or go directly to [choosing
+fidelity](/docs/choosing-fidelity).

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "why-html",
+    "designing-artifacts",
     "choosing-fidelity",
     "wireframes",
     "prototypes",

--- a/site/lib/catalog-data.ts
+++ b/site/lib/catalog-data.ts
@@ -527,6 +527,15 @@ export const catalogSkills: CatalogSkill[] = [
     color: "cobalt",
   },
   {
+    id: "design-artifact",
+    title: "Design artifact",
+    description:
+      "Subject-specific creative direction for reports, plans, diagrams, decks, mockups, prototypes, and tools.",
+    guideUrl: "/docs/designing-artifacts",
+    sourceUrl: `${repoSource}/design-artifact/SKILL.md`,
+    color: "green",
+  },
+  {
     id: "html-wireframe",
     title: "HTML wireframe",
     description:

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -4,9 +4,10 @@
   "groupings": [
     {
       "title": "Effective HTML",
-      "description": "Focused skills for self-contained HTML artifacts, wireframes, prototypes, plans, and diagrams.",
+      "description": "Creative direction and focused workflows for self-contained HTML artifacts, wireframes, prototypes, plans, and diagrams.",
       "skills": [
         "html",
+        "design-artifact",
         "html-wireframe",
         "html-prototype",
         "html-diagram",

--- a/skills/design-artifact/SKILL.md
+++ b/skills/design-artifact/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: design-artifact
+description: Provide subject-specific creative direction for any self-contained HTML artifact, including reports, plans, diagrams, decks, landing pages, mockups, prototypes, and small tools. Use when the user asks for a polished or distinctive visual artifact, when palette, type, composition, or theming remain open, or when another Effective HTML skill needs art direction that avoids generic AI styling. Do not use this skill to override an established design system or a specialist skill's fidelity and behavior contract.
+---
+
+# Design Artifact
+
+Give each HTML artifact a visual identity that belongs to its brief. This skill
+can work alone for broad visual deliverables or alongside `html`,
+`html-wireframe`, `html-prototype`, `html-plan`, or `html-diagram`.
+
+It is creative-direction guidance, not a template. Do not reproduce a house
+palette, type stack, card system, layout, or static reference from a previous
+artifact.
+
+## Compose it with the artifact skill
+
+Let the artifact skill own the form:
+
+- `html` chooses the broad workflow and shared build contract.
+- `html-wireframe` keeps the result intentionally low fidelity.
+- `html-prototype` decides whether the artifact is a mockup or working flow.
+- `html-plan` preserves source commitments and traceability.
+- `html-diagram` chooses the visual model and rendering method.
+- `design-artifact` shapes palette, type, composition, visual register, and the
+  amount of expressive treatment.
+
+Creative direction must not smuggle polish into a wireframe, decoration into a
+plan, or spectacle into a diagram whose relationships need to remain quiet and
+legible.
+
+## Establish authority before taste
+
+Inspect the request, supplied references, and current project before choosing a
+direction. Look for `AGENTS.md`, `CLAUDE.md`, `DESIGN.md`, product documentation,
+tokens, components, screenshots, and nearby artifacts.
+
+Authority runs in this order:
+
+1. The user's explicit instructions and accepted decisions.
+2. The project's established design system and conventions.
+3. The subject, audience, content, and purpose of this artifact.
+4. Your own design judgment.
+
+Use bundled or external references to understand technique and constraints, not
+as a visual answer to copy.
+
+## Size the treatment to the brief
+
+Choose the register before writing CSS:
+
+- **Workmanlike:** quiet hierarchy, exact spacing, restrained color, and direct
+  language for plans, briefs, reports, and many tools.
+- **Editorial:** stronger composition, distinctive type, deliberate pacing, and
+  one memorable move for explainers, launches, research stories, and decks.
+- **Expressive:** a more immersive visual or interactive premise whose execution
+  is part of the message. Use it only when the subject earns it.
+
+Every register deserves care. A memo does not need a theatrical hero, and a
+landing page does not become distinctive merely by becoming louder.
+
+## Derive the direction from the subject
+
+Find one organizing idea in the subject's own world: its materials, tools,
+environment, notation, history, audience, or language. Let that idea influence
+the grid, type, color, imagery, diagram grammar, density, or interaction.
+
+Use real content from the first draft. Placeholder copy, invented metrics, and
+generic product names weaken the design because they remove the constraints that
+should shape it.
+
+Before building, write a short design plan in working notes:
+
+- **Premise:** the visual idea and why it belongs to this subject.
+- **Color:** named roles with actual values, including neutrals and status colors
+  when needed.
+- **Type:** the display, body, and utility roles the content actually needs.
+- **Layout:** the organizing composition and intended reading path.
+- **Interaction:** the one place, if any, where motion or input carries meaning.
+
+Do not satisfy a quota. The number of colors, typefaces, columns, and components
+should follow the idea.
+
+## Apply the fundamentals
+
+### Typography
+
+Use type to establish voice and hierarchy. One well-used family can outperform
+an arbitrary pairing; multiple roles are useful only when they remain coherent.
+Keep prose readable, balance headings, and use tabular numerals where values
+align. Use system fonts when they fit. Embed custom fonts only when their value
+and license justify the file weight; do not depend on a font CDN.
+
+### Color and themes
+
+Choose neutrals as deliberately as accents. Keep semantic status colors separate
+from decorative color. Follow the user's or project's theme policy. When both
+light and dark themes are required, define component-facing tokens and give each
+theme equal care instead of mechanically inverting values. A deliberate
+single-theme concept is valid when the brief calls for it.
+
+### Layout and cascade
+
+Let containers own spacing through grid, flex, and `gap`. Keep prose measures
+readable and place broad tables, diagrams, or code in contained scrolling or
+pannable regions. Organize selectors so component spacing cannot be quietly
+overridden by unrelated rules. Prevent accidental page-level overflow.
+
+### Copy and structure
+
+Treat words as part of the interface. Use the reader's language, active verbs,
+specific labels, and useful error messages. Numbering, labels, dividers, badges,
+and callouts should express real order, state, grouping, or importance rather
+than decorate empty structure.
+
+### Interaction and motion
+
+Make controls look actionable and make their effects clear. Preserve keyboard
+access, visible focus, and state feedback. Allocate motion to explanation,
+continuity, or feedback. Respect `prefers-reduced-motion`; remove animation that
+does not change understanding.
+
+## Avoid the template reflex
+
+Common components are not a visual direction. Cards, pills, rounded rectangles,
+gradients, tiny uppercase labels, giant numerals, side rails, and centered heroes
+may be useful, but each must express something true about the content.
+
+Vary more than color. A new palette on the same hero and card grid is still the
+same design. Reconsider composition, scale, density, typography, shape language,
+navigation, imagery, and interaction.
+
+Current generic AI output often defaults to interchangeable dark dashboards,
+purple-blue gradients, universal rounded cards, safe grotesk type, decorative
+metrics, and effects distributed evenly across the page. Do not reject a choice
+because it is common; reject it when it has no reason to be there.
+
+Concentrate the strongest visual decision in one place and let the rest of the
+artifact support it.
+
+## Build and verify
+
+Follow the active artifact skill's build contract. For a standalone artifact,
+produce one self-contained HTML file with essential CSS and JavaScript inline
+and no network requirement unless the user permits one.
+
+Inspect the result at wide and narrow widths. Exercise the important controls,
+check the console, test keyboard focus and reduced motion, and fix clipping,
+overlap, unreadable text, broken states, and accidental overflow.
+
+Finish with an originality check: if the subject were swapped for a neighboring
+topic, would the visual idea still make just as much sense? If so, revise the
+composition, type, color, imagery, or interaction until the artifact belongs to
+this brief.
+
+Return the absolute path and a short account of the visual premise, register,
+and interaction choices.

--- a/skills/design-artifact/agents/openai.yaml
+++ b/skills/design-artifact/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Design Artifact"
+  short_description: "Creative direction for distinctive HTML artifacts"
+  default_prompt: "Use $design-artifact to give this HTML artifact a subject-specific visual direction."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/html-diagram/SKILL.md
+++ b/skills/html-diagram/SKILL.md
@@ -34,6 +34,11 @@ Use HTML and CSS, SVG, Canvas, or WebGL according to the information and scale. 
 
 Add sequencing, filtering, path tracing, pan and zoom, or animation only when it helps answer the stated question. Keep overlays dismissible, controls keyboard-accessible, and motion compatible with `prefers-reduced-motion`.
 
+When [`design-artifact`](../design-artifact/SKILL.md) is available, read it for
+the diagram's surrounding composition and visual register. Keep the chosen
+diagram grammar, label legibility, and relationships authoritative over
+decorative treatment.
+
 ## Build and verify
 
 Deliver one self-contained HTML file with essential CSS and JavaScript inline. Require no build step or external service. Use accessible text alternatives and keep important meaning available without animation or color alone.

--- a/skills/html-plan/SKILL.md
+++ b/skills/html-plan/SKILL.md
@@ -11,6 +11,11 @@ Turn source material into a plan people can inspect and act on. Preserve the use
 
 Read the conversation, project instructions, and supplied plan before designing. Match an existing design language when one is present. Otherwise derive a quiet, workmanlike direction from the audience and subject.
 
+When [`design-artifact`](../design-artifact/SKILL.md) is available, read its
+fundamentals to make that direction intentional. Keep this skill's traceability
+and source-preservation rules authoritative; creative direction must not
+inflate the plan into a dashboard or campaign page.
+
 Decide what the plan actually needs:
 
 - phases or sequence;

--- a/skills/html-prototype/SKILL.md
+++ b/skills/html-prototype/SKILL.md
@@ -38,6 +38,11 @@ Before coding, settle:
 
 When no design system exists, create a specific direction from the subject and use case. Do not default to a gradient, a dark dashboard, interchangeable cards, or decorative metrics. A prototype for a field tool, an editorial workflow, and a financial approval should not feel like the same product.
 
+When [`design-artifact`](../design-artifact/SKILL.md) is available and the visual
+direction remains open, read and compose it with this skill. Use it to choose
+the register, palette, type, and composition; keep this skill authoritative for
+fidelity, state, and interaction completeness.
+
 ## Scope one credible experience
 
 Choose the smallest flow that can answer the review question. Use realistic, internally consistent names, dates, statuses, quantities, and copy.

--- a/skills/html-wireframe/SKILL.md
+++ b/skills/html-wireframe/SKILL.md
@@ -30,6 +30,10 @@ Use real labels and representative content. Low fidelity is not permission to us
 
 ## Explore structure before style
 
+When [`design-artifact`](../design-artifact/SKILL.md) is available, read it for
+subject-specific composition and hierarchy guidance without importing editorial
+polish. This skill's low-fidelity contract remains authoritative.
+
 When the layout is still unsettled, create two or three meaningfully different directions. Vary product decisions such as:
 
 - navigation model;

--- a/skills/html/SKILL.md
+++ b/skills/html/SKILL.md
@@ -11,6 +11,10 @@ Build one self-contained HTML file that makes the subject clearer, easier to use
 
 Use the narrowest skill that owns the main review question:
 
+- Read and compose [`design-artifact`](../design-artifact/SKILL.md) with the
+  chosen workflow when palette, type, composition, theming, or overall visual
+  register remain open. It provides creative direction; it does not replace the
+  specialist that owns fidelity, structure, or behavior.
 - Read and follow [`html-wireframe`](../html-wireframe/SKILL.md) when structure, information hierarchy, navigation, or task flow is still unsettled. It should remain visibly low fidelity and may compare two or three layout directions.
 - Read and follow [`html-prototype`](../html-prototype/SKILL.md) when the user needs a polished mockup or a working interactive flow. A mockup is the static fidelity mode inside that skill.
 - Read and follow [`html-plan`](../html-plan/SKILL.md) when the artifact is primarily a plan, roadmap, implementation sequence, or rollout document whose source commitments must remain easy to verify.
@@ -38,7 +42,11 @@ Before coding, settle five things in working notes:
 - **Fidelity:** whether to preserve the user's structure and wording or synthesize more freely.
 - **Interaction:** what benefits from exploration, sequencing, filtering, or motion, if anything.
 
-If the project already answers the visual questions, follow it. Otherwise read [`references/creative-direction.md`](references/creative-direction.md) before choosing the palette, type, composition, or motion.
+If the project already answers the visual questions, follow it. Otherwise read
+and compose [`design-artifact`](../design-artifact/SKILL.md) when it is
+available. If the collection was installed without that sibling skill, read
+[`references/creative-direction.md`](references/creative-direction.md) before
+choosing the palette, type, composition, or motion.
 
 ## Load only the guidance the artifact needs
 


### PR DESCRIPTION
## Summary

- add `design-artifact` as a portable creative-direction skill for any self-contained HTML artifact
- compose it with the existing HTML router and wireframe, prototype, diagram, and plan specialists without overriding their fidelity contracts
- expose the sixth skill through skills.sh, Claude, and Codex packaging
- add a guide chapter explaining the generic approach, its optional role, and its inspiration from Anthropic's `web-artifacts-builder` skill
- catalog the new skill and derive catalog skill counts from the data

## Validation

- strict Vercel, Claude, and Codex skill-repository validation
- Codex plugin validation
- `npx skills add . --list` discovers all six skills
- isolated `design-artifact` installation smoke test
- `cd site && pnpm lint`
- `cd site && pnpm typecheck`
- `cd site && pnpm build`
- local checks for `/docs/designing-artifacts` and `/catalog`