### PR TITLE
docs: link HTML wireframes guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Focused agent skills for creating useful, self-contained HTML artifacts, from low-fidelity wireframes to working interactive prototypes.
 
+Read [HTML Wireframes and Prototypes for Coding Agents](https://docs.plannotator.ai/learn/code-context/html-wireframes-and-prototypes-for-coding-agents) for a practical guide to choosing the right level of fidelity, giving an agent useful context, and reviewing the result.
+
 ## Fat artifacts + fat context
 
 A **fat artifact** carries the working detail: structure, visuals, states,

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Focused agent skills for creating useful, self-contained HTML artifacts, from low-fidelity wireframes to working interactive prototypes.
 
-Read [HTML Wireframes and Prototypes for Coding Agents](https://docs.plannotator.ai/learn/code-context/html-wireframes-and-prototypes-for-coding-agents) for a practical guide to choosing the right level of fidelity, giving an agent useful context, and reviewing the result.
-
 ## Fat artifacts + fat context
 
 A **fat artifact** carries the working detail: structure, visuals, states,
@@ -46,8 +44,7 @@ The repo includes six optional skills for pragmatic visual artifacts.
 | [`html-plan`](skills/html-plan/SKILL.md) | Plans, roadmaps, rollouts, and implementation sequences that preserve source commitments |
 | [`html-diagram`](skills/html-diagram/SKILL.md) | Architecture, sequence, process, state, hierarchy, timeline, and system diagrams |
 
-
-
+Practical guide: [HTML Wireframes and Prototypes for Coding Agents](https://docs.plannotator.ai/learn/code-context/html-wireframes-and-prototypes-for-coding-agents).
 
 ## Install
 


### PR DESCRIPTION
## Summary
- link the canonical Plannotator guide for HTML wireframes and prototypes
- keep the reference contextual and limited to one README link

## Verification
- git diff --check
- canonical guide returns HTTP 200
- README contains the canonical URL exactly once