### PR TITLE
fix(marketplace): switch plugin source to explicit HTTPS url form

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "plannotator-effective-html",
       "source": {
-        "source": "github",
-        "repo": "plannotator/effective-html"
+        "source": "url",
+        "url": "https://github.com/plannotator/effective-html.git"
       },
       "description": "Give standalone HTML artifacts a subject-specific visual direction, then create wireframes, styled mockups, interactive prototypes, plans, diagrams, and general artifacts.",
       "homepage": "https://github.com/plannotator/effective-html",


### PR DESCRIPTION
## Symptom

Installing this plugin's Claude Code marketplace entry on a fresh machine with no SSH key configured for `github.com` (no `~/.ssh/known_hosts` entry, no key) fails with an SSH host-key verification error.

## Impact

The `plannotator-effective-html` plugin entry in `.claude-plugin/marketplace.json` uses the `github` owner/repo shorthand source:

```json
"source": {
  "source": "github",
  "repo": "plannotator/effective-html"
}
```

Claude Code resolves this shorthand by cloning over `git@github.com:...` (SSH). Any consumer without a pre-configured SSH key/known-hosts entry for GitHub — a fresh CI runner, a new dev machine, a sandboxed agent host — cannot install the plugin.

## Repro

On a host with no `~/.ssh/known_hosts` entry for `github.com` and no SSH key loaded, add this marketplace and run `claude plugin install plannotator-effective-html@effective-html`. The clone fails at SSH host-key verification.

## Evidence

Upstream HEAD at the time of this PR: `d95debbaef15af1d201fc6c10c77cf92b524a0d6`, `.claude-plugin/marketplace.json` line 10-13.

## Fix

Switch the source to the explicit HTTPS `url` form, which clones over HTTPS and needs no SSH setup:

```json
"source": {
  "source": "url",
  "url": "https://github.com/plannotator/effective-html.git"
}
```

No other files reference the `github`-shorthand source (checked repo-wide); the `.codex-plugin/plugin.json` manifest is a separate, unrelated format with no such field.
